### PR TITLE
Fix syntax errors when compiling standalone_main.cpp

### DIFF
--- a/IsoModel/src/UserModel.hpp
+++ b/IsoModel/src/UserModel.hpp
@@ -89,7 +89,7 @@ public:
    * Generates a MonthlyModel from the properties of the UserModel.
    */
   MonthlyModel toMonthlyModel() const;
-  
+
   /**
    * Generates an HourlyModel from the properties of the UserModel.
    */
@@ -2262,7 +2262,7 @@ private:
   std::string resolveFilename(std::string baseFile, std::string relativeFile);
   void initializeStructure(const Properties& buildingParams);
 
-  std::map<LatLon, std::shared_ptr<WeatherData>> _weather_cache;
+  std::map<LatLon, std::shared_ptr<WeatherData> > _weather_cache;
 
   std::shared_ptr<WeatherData> _weather;
   std::shared_ptr<EpwData> _edata;
@@ -2285,7 +2285,7 @@ private:
   std::string dataFile;
 
   void initializeParameters(const Properties& props);
-  
+
   /**
    * Sets an .ism property in the usermodel to a value gotten from a Properties object.
    * Takes a pointer to the appropriate UserModel setter function, the Properties object,

--- a/IsoModel/src/standalone_main.cpp
+++ b/IsoModel/src/standalone_main.cpp
@@ -93,12 +93,12 @@ void runHourlySimulation(const UserModel& umodel, bool aggregateByMonth) {
 void compare(const UserModel& umodel, bool markdown = false) {
   openstudio::isomodel::HourlyModel hourly = umodel.toHourlyModel();
   auto hourlyResults = hourly.simulate(true);
-  
+
   openstudio::isomodel::MonthlyModel monthlyModel = umodel.toMonthlyModel();
   auto monthlyResults = monthlyModel.simulate();
 
-  auto endUseNames = std::vector<std::string> { "ElecHeat", "ElecCool", "ElecIntLights", "ElecExtLights", "ElecFans", "ElecPump",
-                                                "ElecEquipInt", "ElecEquipExt", "ElectDHW", "GasHeat", "GasCool", "GasEquip", "GasDHW" };
+  std::string endUseNames [] = { "ElecHeat", "ElecCool", "ElecIntLights", "ElecExtLights", "ElecFans", "ElecPump",
+                                 "ElecEquipInt", "ElecEquipExt", "ElectDHW", "GasHeat", "GasCool", "GasEquip", "GasDHW" };
 
   auto delim = markdown ? " | " : ", ";
 
@@ -127,8 +127,8 @@ void compare(const UserModel& umodel, bool markdown = false) {
 
 int main(int argc, char* argv[])
 {
-  namespace po = boost::program_options; 
-  po::options_description desc("Options"); 
+  namespace po = boost::program_options;
+  po::options_description desc("Options");
   desc.add_options()
     ("ismfilepath,i", po::value<std::string>()->required(), "Path to ism file.")
     ("defaultsfilepath,d", "Path to defaults ism file.")
@@ -137,28 +137,28 @@ int main(int argc, char* argv[])
     ("hourlyByHour,H", "Run the hourly simulation (results for each hour).")
     ("compare,c", po::value<std::string>(), "Run the monthly and hourly simulations and compare the results. Use 'md' for markdown and 'csv' for csv.");
 
-  po::positional_options_description positionalOptions; 
-  positionalOptions.add("ismfilepath", 1); 
-  positionalOptions.add("defaultsfilepath", 2); 
+  po::positional_options_description positionalOptions;
+  positionalOptions.add("ismfilepath", 1);
+  positionalOptions.add("defaultsfilepath", 2);
 
   po::variables_map vm;
 
   try {
-    po::store(po::command_line_parser(argc, argv).options(desc).positional(positionalOptions).run(), vm); // Throws on error. 
+    po::store(po::command_line_parser(argc, argv).options(desc).positional(positionalOptions).run(), vm); // Throws on error.
     po::notify(vm); // Throws if required options are mising.
   }
-  catch(boost::program_options::required_option& e) 
-  { 
-    std::cerr << "ERROR: " << e.what() << std::endl << std::endl; 
+  catch(boost::program_options::required_option& e)
+  {
+    std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
     std::cerr << desc << std::endl;
-    return 1; 
-  } 
-  catch(boost::program_options::error& e) 
-  { 
-    std::cerr << "ERROR: " << e.what() << std::endl << std::endl; 
+    return 1;
+  }
+  catch(boost::program_options::error& e)
+  {
+    std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
     std::cerr << desc << std::endl;
-    return 1; 
-  } 
+    return 1;
+  }
 
   if (DEBUG_ISO_MODEL_SIMULATION) {
     std::cout << "Loading User Model..." << std::endl;
@@ -229,5 +229,3 @@ int main(int argc, char* argv[])
   }
 
 }
-
-


### PR DESCRIPTION
On Mac OSX 10.12.2 with
```
$ g++ -v
Configured with: --prefix=/Library/Developer/CommandLineTools/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 8.0.0 (clang-800.0.42.1)
Target: x86_64-apple-darwin16.3.0
Thread model: posix
```
I was getting syntax errors when running
```
g++ -o standalone_main standalone_main.cpp
```
which I'm correcting here (my editor also auto-fixed some extra spaces).

It also seems to be ignoring `ISOMODEL_STANDALONE` since all the "else" conditions for OpenStudio are being hit. Based on [this](https://github.com/Argonne-National-Laboratory/ISOmodel/blob/master/openstudio_integration.md) my understanding is that the default is standalone mode, so some guidance here would be appreciated.